### PR TITLE
Improvements to code

### DIFF
--- a/tmc2209/Cargo.toml
+++ b/tmc2209/Cargo.toml
@@ -11,13 +11,15 @@ homepage = "https://github.com/mitchmindtree/tmc2209"
 edition = "2018"
 
 [dependencies]
-bitfield = "^0.13.2"
-embedded-hal = "^1.0.0"
-embedded-io = "^0.6.1"
-hash32 = { version = "^0.1.1", optional = true }
-hash32-derive = { version = "^0.1", optional = true }
-serde = { version = "^1", default-features = false, features = ["derive"], optional = true }
-ufmt = { version = "^0.1.0", optional = true }
+bitfield = "0.19"
+embedded-hal = "1"
+embedded-io = "0.7"
+hash32 = { version = "1", optional = true }
+hash32-derive = { version = "0.1", optional = true }
+serde = { version = "1", default-features = false, features = [
+    "derive",
+], optional = true }
+ufmt = { version = "0.2", optional = true }
 
 [features]
 hash = ["hash32", "hash32-derive"]

--- a/tmc2209/src/lib.rs
+++ b/tmc2209/src/lib.rs
@@ -246,7 +246,7 @@ impl ReadResponse {
     /// `reg::Address`. See the `register` method.
     pub fn data_u32(&self) -> u32 {
         let d = self.data();
-        bytes_to_u32([d[0], d[1], d[2], d[3]])
+        u32::from_be_bytes([d[0], d[1], d[2], d[3]])
     }
 
     /// Attempt to cast the `data` field to a register bitfield of the given type.
@@ -293,7 +293,7 @@ impl WriteRequest {
     pub fn from_state(slave_addr: u8, state: reg::State) -> Self {
         const WRITE: u8 = 0b10000000;
         let reg_addr_rw = state.addr() as u8 | WRITE;
-        let [b0, b1, b2, b3] = u32_to_bytes(state.into());
+        let [b0, b1, b2, b3] = u32::to_be_bytes(state.into());
         let mut bytes = [
             SYNC_AND_RESERVED,
             slave_addr,
@@ -426,27 +426,6 @@ pub fn crc(data: &[u8]) -> u8 {
         }
     }
     crc
-}
-
-// Helper function for converting a `u32` to bytes in the order they should be written in an access
-// request datagram.
-fn u32_to_bytes(u: u32) -> [u8; 4] {
-    let b0 = (u >> 24) as u8;
-    let b1 = (u >> 16) as u8;
-    let b2 = (u >> 8) as u8;
-    let b3 = u as u8;
-    [b0, b1, b2, b3]
-}
-
-// Helper function for converting the bytes of the data field of an access response datagram to a
-// `u32` value ready for conversion to a register bitfield.
-fn bytes_to_u32([b0, b1, b2, b3]: [u8; 4]) -> u32 {
-    let mut u = 0u32;
-    u |= (b0 as u32) << 24;
-    u |= (b1 as u32) << 16;
-    u |= (b2 as u32) << 8;
-    u |= b3 as u32;
-    u
 }
 
 /// Use the selected sense resistor value (in ohms) and the motor's rated current (in mA) to

--- a/tmc2209/src/reg.rs
+++ b/tmc2209/src/reg.rs
@@ -57,7 +57,11 @@ bitfield! {
     pub test_mode, set_test_mode: 9;
 }
 
+// The GSTAT register is special, it is marked as R+WC, which is a status register that can be
+// written to with 1 bit to clear a flag. For example by setting the drv_err bit to 1, it will clear
+// the drv_err flag on write.
 bitfield! {
+    /// Global status flags register.
     #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
     #[cfg_attr(feature = "hash", derive(hash32_derive::Hash32))]
     #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
@@ -65,8 +69,21 @@ bitfield! {
     pub struct GSTAT(u32);
     impl Debug;
     u8;
+    /// Indicates that the IC has been reset since the last read access to GSTAT.
+    /// All regisers have been cleared to reset values.
     pub reset, _: 0;
-    pub drv_err, _: 1;
+    /// Indicates, that the driver has been shut down due to overtemperature or
+    /// short circuit detection since the last read access.
+    /// Read [`DRV_STATUS`] for details.
+    ///
+    /// The flag can only be cleared when all error conditions are cleared.
+    /// To clear the flag, call `set_drv_err(true)`, and then write the register
+    /// to the driver.
+    pub drv_err, set_drv_err: 1;
+    /// Indicates an undervoltage on the charge pump.
+    /// The driver is disabled in this case.
+    ///
+    /// This flag is not latched and thus does not need to be cleared.
     pub uv_cp, _: 2;
 }
 

--- a/tmc2209/src/reg.rs
+++ b/tmc2209/src/reg.rs
@@ -695,15 +695,15 @@ macro_rules! impl_registers {
             }
         }
 
-        impl Into<u8> for Address {
-            fn into(self) -> u8 {
-                self as u8
+        impl From<Address> for u8 {
+            fn from(address: Address) -> u8 {
+                address as u8
             }
         }
 
-        impl Into<u32> for State {
-            fn into(self) -> u32 {
-                match self {
+        impl From<State> for u32 {
+            fn from(state: State) -> u32 {
+                match state {
                     $(
                         State::$T(r) => r.into(),
                     )*
@@ -737,9 +737,9 @@ macro_rules! impl_registers {
                 }
             }
 
-            impl Into<u32> for $T {
-                fn into(self) -> u32 {
-                    self.0 as u32
+            impl From<$T> for u32 {
+                fn from(value: $T) -> u32 {
+                    value.0 as u32
                 }
             }
 

--- a/tmc2209/src/reg.rs
+++ b/tmc2209/src/reg.rs
@@ -7,6 +7,8 @@
 
 #![allow(non_camel_case_types)]
 
+use crate::data::{MicroStepResolution, StandstillMode};
+
 // Register Traits
 // --------------------------------------------------------
 
@@ -733,7 +735,7 @@ bitfield! {
     ///
     /// In general the number of microsteps can be converted to the value the driver understands
     /// by calculating `8 - log2(microsteps)`. For example, for 16 microsteps, `8 - log2(16) = 4`.
-    pub mres, set_mres: 27, 24;
+    pub from into MicroStepResolution, mres, set_mres: 27, 24;
     /// Interpolation to 256 microsteps.
     ///
     /// When enabled, the actual microstep resolution ([`CHOPCONF::mres`])
@@ -903,7 +905,7 @@ bitfield! {
     /// - `0b01`: Freewheeling
     /// - `0b10`: Coil shorted using LS drivers (Passive Braking)
     /// - `0b11`: Coil shorted using HS drivers (Passive Braking)
-    pub freewheel, set_freewheel: 21, 20;
+    pub from into StandstillMode, freewheel, set_freewheel: 21, 20;
     /// Regulation loop gradient
     ///
     /// User defined maximum PWM amplitude change per half wave when using `pwm_autoscale=1`.

--- a/tmc2209/src/reg.rs
+++ b/tmc2209/src/reg.rs
@@ -98,7 +98,7 @@ bitfield! {
     /// Whether to enable test mode.
     ///
     /// If set to true, it will enable analog test output on ENN pin (pull down resistor off), ENN treated as enabled.
-    /// `IHOLD[1..0]` selects the function of `DC0`: 0..2: T120, DAC, VDDH.
+    /// `IHOLD[1..0]` selects the function of `DCO`: 0..2: T120, DAC, VDDH.
     ///
     /// Attention: Not for user, set to 0 for normal operation!
     pub test_mode, set_test_mode: 9;
@@ -224,8 +224,8 @@ bitfield! {
     /// differs between individual ICs! It should not be altered.
     pub otp_fclktrim, _: 4, 0;
     /// Reset default for OTTRIM:
-    /// - 0: OTTRIM= %00 (143°C)
-    /// - 1: OTTRIM= %01 (150°C)
+    /// - 0: `OTTRIM=0b00` (143°C)
+    /// - 1: `OTTRIM=0b01` (150°C)
     /// (internal power stage temperature about 10°C above the sensor temperature limit)
     pub otp_ottrim, _: 5;
     /// Reset default for GCONF.internal_Rsense
@@ -302,25 +302,25 @@ bitfield! {
     /// This value will set the default value for 8th bit in the `CHOPCONF` register (hend1).
     pub otp_pwm_ofs, _: 16;
     /// Reset default for PWM_REG:
-    /// - 0: PWM_REG=%1000: max. 4 increments / cycle
-    /// - 1: PWM_REG=%0010: max. 1 increment / cycle
+    /// - 0: `PWM_REG=0b1000`: max. 4 increments / cycle
+    /// - 1: `PWM_REG=0b0010`: max. 1 increment / cycle
     pub otp_pwm_reg, _: 17;
     /// Reset default for PWM_FREQ:
-    /// - 0: PWM_FREQ=%01=2/683
-    /// - 1: PWM_FREQ=%10=2/512
+    /// - 0: `PWM_FREQ=0b01=2/683`
+    /// - 1: `PWM_FREQ=0b10=2/512`
     pub otp_pwm_freq, _: 18;
     /// Reset default for IHOLDDELAY
-    /// - %00: IHOLDDELAY= 1
-    /// - %01: IHOLDDELAY= 2
-    /// - %10: IHOLDDELAY= 4
-    /// - %11: IHOLDDELAY= 8
+    /// - `0b00`: IHOLDDELAY= 1
+    /// - `0b01`: IHOLDDELAY= 2
+    /// - `0b10`: IHOLDDELAY= 4
+    /// - `0b11`: IHOLDDELAY= 8
     pub otp_ihold_delay, _: 20, 19;
     /// Reset default for standstill current IHOLD (used only if
     /// current reduction enabled, e.g. pin PDN_UART low).
-    /// - %00: IHOLD= 16 (53% of IRUN)
-    /// - %01: IHOLD= 2 ( 9% of IRUN)
-    /// - %10: IHOLD= 8 (28% of IRUN)
-    /// - %11: IHOLD= 24 (78% of IRUN)
+    /// - `0b00`: IHOLD= 16 (53% of IRUN)
+    /// - `0b01`: IHOLD= 2 ( 9% of IRUN)
+    /// - `0b10`: IHOLD= 8 (28% of IRUN)
+    /// - `0b11`: IHOLD= 24 (78% of IRUN)
     ///
     /// (Reset default for run current IRUN=31)
     pub otp_ihold, _: 22, 21;
@@ -382,7 +382,7 @@ bitfield! {
     u8;
     /// FCLKTRIM (Reset default: OTP)
     ///
-    /// 0…31: Lowest to highest clock frequency. Check at charge pump output.
+    /// 0...31: Lowest to highest clock frequency. Check at charge pump output.
     /// The frequency span is not guaranteed, but it is tested, that tuning to 12MHz
     /// internal clock is possible. The devices come preset to 12MHz clock frequency
     /// by OTP programming.
@@ -686,16 +686,16 @@ bitfield! {
     ///
     /// (Default: OTP, resp. 3 in StealthChop mode)
     pub toff, set_toff: 3, 0;
-    /// %000 … %111:
-    /// Add 1, 2, …, 8 to hysteresis low value HEND
+    /// `0b000` ... `0b111`:
+    /// Add 1, 2, ..., 8 to hysteresis low value HEND
     /// (1/512 of this setting adds to current setting)
     /// Attention: Effective HEND+HSTRT ≤ 16.
     /// Hint: Hysteresis decrement is done each 16 clocks
     ///
     /// (Default: OTP, resp. 5 in StealthChop mode)
     pub hstrt, set_hstrt: 6, 4;
-    /// %0000 … %1111:
-    /// Hysteresis is -3, -2, -1, 0, 1, …, 12
+    /// `0b0000` ... `0b1111`:
+    /// Hysteresis is -3, -2, -1, 0, 1, ..., 12
     /// (1/512 of this setting adds to current setting)
     ///
     /// This is the hysteresis value which becomes used for the

--- a/tmc2209/src/reg.rs
+++ b/tmc2209/src/reg.rs
@@ -134,18 +134,23 @@ bitfield! {
     pub uv_cp, _: 2;
 }
 
-/// Interface transmission counter.
-///
-/// This register becomes incremented with each successful UART interface write access.
-/// Read out to check the serial transmission for lost data. Read accesses do not change
-/// the content.
-///
-/// The counter wraps around from 255 to 0, it should be a value between 0 and 255 (inclusive).
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "hash", derive(hash32_derive::Hash32))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "ufmt", derive(ufmt::derive::uDebug))]
-pub struct IFCNT(pub u32);
+bitfield! {
+    /// Interface transmission counter.
+    ///
+    /// This register becomes incremented with each successful UART interface write access.
+    /// Read out to check the serial transmission for lost data. Read accesses do not change
+    /// the content.
+    ///
+    /// The counter wraps around from 255 to 0, it should be a value between 0 and 255 (inclusive).
+    #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
+    #[cfg_attr(feature = "hash", derive(hash32_derive::Hash32))]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "ufmt", derive(ufmt::derive::uDebug))]
+    pub struct IFCNT(u32);
+    impl Debug;
+    u8;
+    pub get, set: 7, 0;
+}
 
 bitfield! {
     /// SENDDELAY for read access (time until reply is sent):
@@ -309,7 +314,7 @@ bitfield! {
     /// - %01: IHOLDDELAY= 2
     /// - %10: IHOLDDELAY= 4
     /// - %11: IHOLDDELAY= 8
-    pub otp_iholdddelay, _: 20, 19;
+    pub otp_ihold_delay, _: 20, 19;
     /// Reset default for standstill current IHOLD (used only if
     /// current reduction enabled, e.g. pin PDN_UART low).
     /// - %00: IHOLD= 16 (53% of IRUN)
@@ -434,18 +439,23 @@ bitfield! {
     pub ihold_delay, set_ihold_delay: 19, 16;
 }
 
-/// Sets the delay time from stand still ([`DRV_STATUS::stst`]) detection to motor current power down.
-///
-/// Time range is about 0 to 5.6 seconds. Setting 0 is no delay, 1 a minimum delay.
-/// Further increment is in discrete steps of 2^18 clock cycles (value * 2^18 * t_CLK).
-///
-/// Attention: A minimum setting of 2 is required to allow automatic
-/// tuning of StealthChop `PWM_OFFS_AUTO`.
-#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "hash", derive(hash32_derive::Hash32))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "ufmt", derive(ufmt::derive::uDebug))]
-pub struct TPOWERDOWN(pub u32);
+bitfield! {
+    /// Sets the delay time from stand still ([`DRV_STATUS::stst`]) detection to motor current power down.
+    ///
+    /// Time range is about 0 to 5.6 seconds. Setting 0 is no delay, 1 a minimum delay.
+    /// Further increment is in discrete steps of 2^18 clock cycles (value * 2^18 * t_CLK).
+    ///
+    /// Attention: A minimum setting of 2 is required to allow automatic
+    /// tuning of StealthChop `PWM_OFFS_AUTO`.
+    #[derive(Clone, Copy, Eq, Hash, PartialEq)]
+    #[cfg_attr(feature = "hash", derive(hash32_derive::Hash32))]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "ufmt", derive(ufmt::derive::uDebug))]
+    pub struct TPOWERDOWN(u32);
+    impl Debug;
+    u8;
+    pub get, set: 7, 0;
+}
 
 bitfield! {
     /// Actual measured time between two 1/256 microsteps.
@@ -535,15 +545,20 @@ bitfield! {
     pub get, set: 19, 0;
 }
 
-/// Detection threshold for stall.
-///
-/// The StallGuard value [`SG_RESULT`] becomes compared to the double of this threshold.
-/// A stall is signaled with `SG_RESULT <= SGTHRS * 2`
-#[derive(Clone, Copy, Debug, Default, Eq, Hash, PartialEq)]
-#[cfg_attr(feature = "hash", derive(hash32_derive::Hash32))]
-#[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
-#[cfg_attr(feature = "ufmt", derive(ufmt::derive::uDebug))]
-pub struct SGTHRS(pub u32);
+bitfield! {
+    /// Detection threshold for stall.
+    ///
+    /// The StallGuard value [`SG_RESULT`] becomes compared to the double of this threshold.
+    /// A stall is signaled with `SG_RESULT <= SGTHRS * 2`
+    #[derive(Clone, Copy, Default, Eq, Hash, PartialEq)]
+    #[cfg_attr(feature = "hash", derive(hash32_derive::Hash32))]
+    #[cfg_attr(feature = "serde", derive(serde::Deserialize, serde::Serialize))]
+    #[cfg_attr(feature = "ufmt", derive(ufmt::derive::uDebug))]
+    pub struct SGTHRS(u32);
+    impl Debug;
+    u8;
+    pub get, set: 7, 0;
+}
 
 bitfield! {
     /// StallGuard result.

--- a/tmc2209/src/reg.rs
+++ b/tmc2209/src/reg.rs
@@ -169,7 +169,7 @@ bitfield! {
     pub struct SLAVECONF(u32);
     impl Debug;
     u8;
-    pub get, set: 11, 8;
+    pub send_delay, set_send_delay: 11, 8;
 }
 
 bitfield! {
@@ -195,7 +195,7 @@ bitfield! {
     /// Set to 0xbd to enable programming.
     ///
     /// A programming time of minimum 10ms per bit is recommended (check by reading [`OTP_READ`]).
-    pub opt_magic, set_otp_magic: 15, 8;
+    pub otp_magic, set_otp_magic: 15, 8;
 }
 
 bitfield! {
@@ -367,7 +367,7 @@ bitfield! {
     u8;
     /// Version number of the IC.
     ///
-    /// `0x24` is the first version of the IC, identical numbers mean full digital compatibility.
+    /// `0x21` is the first version of the IC, identical numbers mean full digital compatibility.
     pub version, _: 31, 24;
 }
 
@@ -1466,7 +1466,7 @@ impl Default for TPOWERDOWN {
 fn test_slaveconf() {
     let mut s = SLAVECONF(0);
     assert_eq!(s.0, 0b000000000000);
-    s.set(15);
+    s.set_send_delay(15);
     assert_eq!(s.0, 0b111100000000);
 }
 

--- a/tmc2209/src/reg.rs
+++ b/tmc2209/src/reg.rs
@@ -219,9 +219,11 @@ bitfield! {
     /// - 0: lowest frequency setting
     /// - 31: highest frequency setting
     ///
-    /// **Attention**: This value is pre-programmed by factory clock
+    /// <div class="warning">
+    /// <b>Attention</b>: This value is pre-programmed by factory clock
     /// trimming to the default clock frequency of 12MHz and
     /// differs between individual ICs! It should not be altered.
+    /// </div>
     pub otp_fclktrim, _: 4, 0;
     /// Reset default for OTTRIM:
     /// - 0: `OTTRIM=0b00` (143°C)
@@ -237,67 +239,55 @@ bitfield! {
     /// - 0: `TBL=0b10`
     /// - 1: `TBL=0b01`
     pub otp_tbl, _: 7;
-    /// Depending on [`otp_en_spread_cycle`]:
+    /// # StealthChop enabled by default:
     ///
-    /// ### `otp_en_spread_cycle == false` (StealthChop enabled by default)
+    /// Reset default for [`PWMCONF::pwm_grad`] as defined by (0..15):
+    /// | Value | PWM_GRAD | Value | PWM_GRAD |
+    /// |-------|----------|-------|----------|
+    /// |  0    |       14 |     8 |       40 |
+    /// |  1    |       16 |     9 |       46 |
+    /// |  2    |       18 |    10 |       52 |
+    /// |  3    |       21 |    11 |       59 |
+    /// |  4    |       24 |    12 |       67 |
+    /// |  5    |       27 |    13 |       77 |
+    /// |  6    |       31 |    14 |       88 |
+    /// |  7    |       35 |    15 |      100 |
     ///
-    /// Reset default for PWM_GRAD as defined by (0..15):
-    /// - 0: PWM_GRAD= 14
-    /// - 1: PWM_GRAD= 16
-    /// - 2: PWM_GRAD= 18
-    /// - 3: PWM_GRAD= 21
-    /// - 4: PWM_GRAD= 24
-    /// - 5: PWM_GRAD= 27
-    /// - 6: PWM_GRAD= 31
-    /// - 7: PWM_GRAD= 35
-    /// - 8: PWM_GRAD= 40
-    /// - 9: PWM_GRAD= 46
-    /// - 10: PWM_GRAD= 52
-    /// - 11: PWM_GRAD= 59
-    /// - 12: PWM_GRAD= 67
-    /// - 13: PWM_GRAD= 77
-    /// - 14: PWM_GRAD= 88
-    /// - 15: PWM_GRAD= 100
+    /// # SpreadCycle enabled by default:
     ///
-    /// ### `otp_en_spread_cycle == true` (SpreadCycle enabled by default)
-    ///
-    /// This value will set the default bits 0 to 3 in the `CHOPCONF` register (TOFF).
+    /// This value will set the default bits `0` to `3` in the [`CHOPCONF`] register (`TOFF`).
     pub otp_pwm_grad, _: 11, 8;
-    /// Depending on [`otp_en_spread_cycle`]:
-    ///
-    /// ### `otp_en_spread_cycle == false` (StealthChop enabled by default)
+    /// # StealthChop enabled by default:
     ///
     /// If `true`, `pwm_autograd` is enabled, otherwise disabled.
     ///
-    /// ### `otp_en_spread_cycle == true` (SpreadCycle enabled by default)
+    /// # SpreadCycle enabled by default:
     ///
     /// This value will set the default value for 4th bit in the `CHOPCONF` register (hstrt0) (pwm_autograd=1).
     pub otp_pwm_autograd, _: 12;
-    /// Depending on [`otp_en_spread_cycle`]:
-    ///
-    /// ### `otp_en_spread_cycle == false` (StealthChop enabled by default)
+    /// # StealthChop enabled by default:
     ///
     /// Reset default for TPWM_THRS as defined by (0..7):
-    /// - 0: TPWM_THRS= 0
-    /// - 1: TPWM_THRS= 200
-    /// - 2: TPWM_THRS= 300
-    /// - 3: TPWM_THRS= 400
-    /// - 4: TPWM_THRS= 500
-    /// - 5: TPWM_THRS= 800
-    /// - 6: TPWM_THRS= 1200
-    /// - 7: TPWM_THRS= 4000
+    /// | Value | TPWM_THRS |
+    /// |-------|-----------|
+    /// | 0     |         0 |
+    /// | 1     |       200 |
+    /// | 2     |       300 |
+    /// | 3     |       400 |
+    /// | 4     |       500 |
+    /// | 5     |       800 |
+    /// | 6     |      1200 |
+    /// | 7     |      4000 |
     ///
-    /// ### `otp_en_spread_cycle == true` (SpreadCycle enabled by default)
+    /// # SpreadCycle enabled by default:
     ///
     /// This value will set the default bits 5 to 7 in the `CHOPCONF` register (hstrt1, hstrt2 and hend0).
     pub otp_tpwmthrs, _: 15, 13;
-    /// Depending on [`otp_en_spread_cycle`]:
-    ///
-    /// ### `otp_en_spread_cycle == false` (StealthChop enabled by default)
+    /// # StealthChop enabled by default:
     ///
     /// This field will set the `PWM_OFS` to `36` (if false) or `0` (if true).
     ///
-    /// ### `otp_en_spread_cycle == true` (SpreadCycle enabled by default)
+    /// # SpreadCycle enabled by default:
     ///
     /// This value will set the default value for 8th bit in the `CHOPCONF` register (hend1).
     pub otp_pwm_ofs, _: 16;
@@ -389,10 +379,12 @@ bitfield! {
     pub fclktrim, set_fclktrim: 4, 0;
     /// OTTRIM (Default: OTP)
     ///
-    /// - `0b00`: OT=143°C, OTPW=120°C
-    /// - `0b01`: OT=150°C, OTPW=120°C
-    /// - `0b10`: OT=150°C, OTPW=143°C
-    /// - `0b11`: OT=157°C, OTPW=143°C
+    /// | Value  | OT    | OTPW  |
+    /// |--------|-------|-------|
+    /// | `0b00` | 143°C | 120°C |
+    /// | `0b01` | 150°C | 120°C |
+    /// | `0b10` | 150°C | 143°C |
+    /// | `0b11` | 157°C | 143°C |
     pub ottrim, set_ottrim: 9, 8;
 }
 

--- a/tmc2209/src/reg.rs
+++ b/tmc2209/src/reg.rs
@@ -1056,25 +1056,49 @@ impl VACTUAL {
 
 impl Default for GCONF {
     fn default() -> Self {
-        Self(0x00000041)
+        let mut result = Self(0);
+
+        result.set_i_scale_analog(true);
+        result.set_pdn_disable(true);
+
+        result
     }
 }
 
 impl Default for IHOLD_IRUN {
     fn default() -> Self {
-        Self(0x00001F00)
+        let mut result = Self(0);
+
+        result.set_irun(31);
+
+        result
     }
 }
 
 impl Default for CHOPCONF {
     fn default() -> Self {
-        Self(0x10000053)
+        let mut result = Self(0);
+
+        result.set_toff(3);
+        result.set_hstrt(5);
+        result.set_intpol(true);
+
+        result
     }
 }
 
 impl Default for PWMCONF {
     fn default() -> Self {
-        Self(0xC10D0024)
+        let mut result = Self(0);
+
+        result.set_pwm_ofs(36);
+        result.set_pwm_freq(1);
+        result.set_pwm_autoscale(true);
+        result.set_pwm_autograd(true);
+        result.set_pwm_reg(1);
+        result.set_pwm_lim(12);
+
+        result
     }
 }
 
@@ -1105,4 +1129,24 @@ fn test_gconf() {
     assert_eq!(g.0, 0b1000000001);
     g = Default::default();
     assert_eq!(g.0, 0x00000041);
+}
+
+#[test]
+fn test_gconf_default() {
+    assert_eq!(GCONF::default(), GCONF(0x00000041));
+}
+
+#[test]
+fn test_ihold_irun_default() {
+    assert_eq!(IHOLD_IRUN::default(), IHOLD_IRUN(0x00001F00));
+}
+
+#[test]
+fn test_chopconf_default() {
+    assert_eq!(CHOPCONF::default(), CHOPCONF(0x10000053));
+}
+
+#[test]
+fn test_pwmconf_default() {
+    assert_eq!(PWMCONF::default(), PWMCONF(0xC10D0024));
 }


### PR DESCRIPTION
My project is using a TMC2209, and instead of porting the [`TMC2209`](https://github.com/janelia-arduino/TMC2209) arduino library over to rust, I am using your crate instead.
I wrote a wrapper on top of your crate, but I think it would be better to upstream these changes into your project, which is why I made this PR.

What has been changed?
- [x] Update dependencies
- [x] Remove `^` in the versions which cargo does by default
- [x] Allow setting `drv_err` in `GSTAT` to be able to clear the flag
- [x] Document all registers based on the datasheet
- [x] Fix some mismatches between datasheet and impl (like a u16 was used for a value that can be negative)
- [x] Fix clippy lints